### PR TITLE
Adding tunables LWRP

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Parameters:
 
 * `need_reboot` (optional) - Add -P to the chdev command if device is busy
 
+
 ### no
 
 Change any AIX no (network) tunables. Example:
@@ -153,6 +154,47 @@ Actions:
 * `reset` - reset a list of tunabes
 * `reset_all` - reset all tunables to default
 * `reset_all_with_reboot` - reset all tunables to default even if the ones that need a reboot
+
+### tunables
+
+Change any AIX unrestricted tunables(vmo, ioo, schedo). Example:
+
+```ruby
+aix_tunables "reset schedo values" do
+  mode :schedo
+  action :reset_all
+  permanent
+end
+
+aix_tunables "change vpm_throughput_mode" do
+  mode :schedo
+  tunables(:vpm_throughput_mode => 2)
+  permanent
+end
+
+aix_tunables "change posix AIO servers" do
+  mode :ioo
+  tunables(posix_aio_minservers: 6, posix_aio_maxservers: 36)
+end
+
+aix_tunables "tune minperm%" do
+  mode :vmo
+  tunables( :"minperm%" => 6)
+  permanent
+end
+```
+
+Parameters:
+
+* `mode` (mandatory) (no default) - must be :ioo, :vmo or :schedo
+* `permament` (optional) (default false) - All changes are persistent
+* `nextboot` (optional) (default false) - All changes applied on next boot only
+
+Actions:
+
+* `update` - update a list of tunables
+* `reset` - reset a list of tunabes
+* `reset_all` - reset all tunables to default
 
 ### multibos
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Change any AIX no (network) tunables. Example:
 ```ruby
 aix_no "changing no tunables" do
   tunables(:udp_recv_perf => 0, :udprecvspace => 42083, :psetimers => 23)
-  set_default 
+  set_default
   action :update
 end
 
@@ -172,7 +172,7 @@ end
 aix_multibos "remove standby multibos" do
   action :remove
 end
- 
+
 aix_multibos "update a multibos" do
   action :update
   update_device "/mnt/7100-03-05-1524"
@@ -336,7 +336,7 @@ $ lsnim -l 7100-03-05-1524-lpp_source
    server      = master
 ```
 
-Here are a few examples of recipes using nimclient: 
+Here are a few examples of recipes using nimclient:
 
 ```ruby
 aix_nimclient "updating to latest available sp" do
@@ -408,11 +408,11 @@ end
 
 Parameters:
 
-* `spot` (optional) - name of the spot 
-* `lpp_source` (optional) - name of the lpp_source 
+* `spot` (optional) - name of the spot
+* `lpp_source` (optional) - name of the lpp_source
 * `installp_bundle` (optional) - name of the installp_bundle
 * `filesets` - list of filesets to install
-* `fixes` - fixe to install 
+* `fixes` - fixe to install
 * `installp_flags` - flags used for installp
 
 Actions:
@@ -424,9 +424,9 @@ Actions:
 * `disable_push` -  disable push operation from client
 * `set_date` - set date to that of the nim master
 * `enable_crypto` - enable secure nimsh
-* `disable_crypto` - disable secure nimsh 
+* `disable_crypto` - disable secure nimsh
 * `reset` - reset the client
-* `bos_inst` - enable bos_install installation (you need to reboot the virtual machine after that) 
+* `bos_inst` - enable bos_install installation (you need to reboot the virtual machine after that)
 * `maint_boot` - ennable maintenance boot (you need to reboot the virtual machine after that)
 
 ## License and Authors

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ aix_tunables "tune minperm%" do
   tunables( :"minperm%" => 6)
   permanent
 end
+
+aix_tunables "tune tcp buffers" do
+  mode :vmo
+  tunables( :udp_recvspace => 655360, :udp_sendspace => 65536 )
+  permanent
+end
 ```
 
 Parameters:
@@ -476,6 +482,7 @@ Actions:
 * Author:: Julian C. Dunn (<jdunn@getchef.com>)
 * Author:: Christoph Hartmann (<chris@lollyrock.com>)
 * Author:: Benoit Creau (<benoit.creau@chmod666.org>)
+* Author:: Alain Dejoux (<adejoux@djouxtech.net>)
 
 ```text
 Copyright:: 2014-2015 Chef Software, Inc.

--- a/providers/tunables.rb
+++ b/providers/tunables.rb
@@ -152,3 +152,5 @@ action :reset_all do
     so = shell_out(string_shell_out)
   end
 end
+
+private :cmd, :gen_shell_out

--- a/providers/tunables.rb
+++ b/providers/tunables.rb
@@ -1,0 +1,154 @@
+#
+# Author:: Alain Dejoux (<adejoux@djouxtech.net>)
+# Cookbook Name:: aix
+# Provider:: tunables
+#
+# Copyright:: 2015, Alain Dejoux
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'chef/mixin/shell_out'
+
+include Chef::Mixin::ShellOut
+
+use_inline_resources
+
+# support whyrun
+def whyrun_supported?
+  true
+end
+
+# get command name
+def cmd
+  @new_resource.mode.to_s
+end
+
+# generate command line
+def gen_shell_out(params: nil, tunable: nil)
+  params = " -p #{params}" if @new_resource.permanent
+  if tunable and [ "R", "B", "I"].include? @current_resource.tunables[tunable][:type]
+    params.sub! "-p", "-r"
+  end
+  "#{cmd} #{params}"
+end
+
+# loading current resource
+def load_current_resource
+  @current_resource = Chef::Resource::AixTunables.new(@new_resource.name)
+
+  so = shell_out("#{cmd} -x")
+  if so.exitstatus != 0
+    raise("#{cmd}: error running #{cmd} -x")
+  end
+
+  # initializing tunables attribute
+  all_tunables = Hash.new
+  so.stdout.each_line do |line|
+    # info:tunable,current,default,reboot,min,max,unit,type,{dtunable }
+    # current = current value
+    # default = default value
+    # reboot = reboot value
+    # min = minimal value
+    # max = maximum value
+    # unit = tunable unit of measure
+    # type = parameter type:
+    #  * D (for Dynamic),
+    #  * S (for Static),
+    #  * R (for Reboot),
+    #  * B (for Bosboot),
+    #  * M (for Mount),
+    #  * I (for Incremental),
+    #  * C (for Connect),
+    #  * d (for Deprecated)
+    #  * dtunable = space separated list of dependent tunable parameters
+    # no output is separted with ','
+    current_tunable = line.split(",")
+    all_tunables[current_tunable[0].to_sym] = {
+      :current => current_tunable[1],
+      :default => current_tunable[2],
+      :reboot => current_tunable[3],
+      :min => current_tunable[4],
+      :max => current_tunable[5],
+      :unit => current_tunable[6],
+      :type => current_tunable[7],
+      :dtunable => current_tunable[8] || "none"
+    }
+  end
+  @current_resource.tunables(all_tunables)
+  Chef::Log.debug(@current_resource.tunables)
+end
+
+# update action
+action :update do
+  # for each tunables ...
+  Chef::Log.debug(@new_resource.tunables)
+  @new_resource.tunables.each do |tunable,value|
+    # raise error if tunable doesn't exist
+    unless @current_resource.tunables.has_key?(tunable.intern)
+      raise "#{cmd}: #{tunable} does not exist"
+    end
+
+    Chef::Log.debug("#{cmd}: setting tunable #{tunable} with value #{value}")
+    # next if value already set
+    if @current_resource.tunables[tunable.intern][:current] == value.to_s
+      Chef::Log.info("#{cmd}: tunable #{tunable} is already set to value #{value}")
+    else
+      Chef::Log.debug("#{cmd}: #{tunable} will be set to value #{value}")
+      converge_by("#{cmd}: setting tunable #{tunable}=#{value}") do
+        string_shell_out = gen_shell_out params: "-o #{tunable}=#{value} ", tunable: tunable.intern
+        Chef::Log.debug("command: #{string_shell_out}")
+        so = shell_out(string_shell_out)
+        # if the command fails raise and exception
+        if so.exitstatus != 0
+          raise "no: #{string_shell_out} failed"
+        end
+      end
+    end
+  end
+end
+
+# reset action
+action :reset do
+  # for each tunables ...
+  Chef::Log.debug(@new_resource.tunables)
+  @new_resource.tunables.each do |tunable,value|
+    # raise error if tunable doesn't exist
+    unless @current_resource.tunables.has_key?(tunable.intern)
+      raise "#{cmd}: #{tunable} does not exist"
+    end
+
+    if @current_resource.tunables[tunable.intern][:current] == value.to_s
+      Chef::Log.info("#{cmd}: tunable #{tunable} is already set to default value #{value}")
+    else
+      Chef::Log.debug("#{cmd}: reseting tunable #{tunable}")
+      converge_by("#{cmd}: reseting tunable #{tunable}") do
+        string_shell_out = gen_shell_out params: " -d #{tunable}", tunable: tunable.intern
+        Chef::Log.debug("command: #{string_shell_out}")
+        so = shell_out(string_shell_out)
+        # if the command fails raise and exception
+        if so.exitstatus != 0
+          raise "#{cmd}: #{string_shell_out} failed"
+        end
+      end
+    end
+  end
+end
+
+action :reset_all do
+  converge_by("#{cmd} : resetting all") do
+    string_shell_out = "#{cmd} -D"
+    if @new_resource.nextboot
+      string_shell_out = "yes | #{cmd} -r -D"
+    end
+    so = shell_out(string_shell_out)
+  end
+end

--- a/resources/tunables.rb
+++ b/resources/tunables.rb
@@ -1,0 +1,9 @@
+actions :update, :reset, :reset_all
+default_action :update
+attr_accessor :exists
+
+attribute :name, :name_attribute => true, :kind_of => String
+attribute :mode, :kind_of => Symbol, :equal_to => [:ioo,:vmo,:schedo, :no], :required => true
+attribute :tunables, :kind_of => Hash
+attribute :permanent, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :nextboot, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
Hello,

I created a LWRP to manage generic tunables commands ioo, vmo and schedo. 

Here a example output when running the example I provided in README :
~~~
root@adxlpar1(/tools/chef)# chef-solo -c solo.rb -j test.json              
[2015-08-24T17:54:30+02:00] WARN: Please install an English UTF-8 locale for Chef to use, falling back to C locale and disabling UTF-8 support.
Starting Chef Client, version 12.4.1
Compiling Cookbooks...
Converging 4 resources
Recipe: aix::default
  * aix_tunables[reset schedo values] action reset_all
    - schedo : resetting all
  * aix_tunables[change vpm_throughput_mode] action update
    - schedo: setting tunable vpm_throughput_mode=2
  * aix_tunables[change posix AIO servers] action update
    - ioo: setting tunable posix_aio_minservers=6
    - ioo: setting tunable posix_aio_maxservers=36
  * aix_tunables[tune minperm%] action update
    - vmo: setting tunable minperm%=6

Running handlers:
Running handlers complete
Chef Client finished, 4/4 resources updated in 6.027071 seconds
~~~

Running it again :

~~~
root@adxlpar1(/tools/chef)# chef-solo -c solo.rb -j test.json
[2015-08-24T17:54:48+02:00] WARN: Please install an English UTF-8 locale for Chef to use, falling back to C locale and disabling UTF-8 support.
Starting Chef Client, version 12.4.1
Compiling Cookbooks...
Converging 4 resources
Recipe: aix::default
  * aix_tunables[reset schedo values] action reset_all
    - schedo : resetting all
  * aix_tunables[change vpm_throughput_mode] action update
    - schedo: setting tunable vpm_throughput_mode=2
  * aix_tunables[change posix AIO servers] action update (up to date)
  * aix_tunables[tune minperm%] action update (up to date)

Running handlers:
Running handlers complete
Chef Client finished, 2/4 resources updated in 5.837877 seconds
~~~

Say if you want me to change anything in it. 

Regards,

Alain
