### PR TITLE
Clean up ShellOut related stuff.

### DIFF
--- a/providers/altdisk.rb
+++ b/providers/altdisk.rb
@@ -171,12 +171,7 @@ action :customize do
   if @current_resource.exists
     Chef::Log.info('alt_disk: customize')
     disk = get_current_alt
-    customize = false
-    customize = if defined?(@new_resource.image_location)
-                  true
-                else
-                  false
-                end
+    customize = defined?(@new_resource.image_location)
     if disk != 'None' && customize
       converge_by('alt_disk: customize alt_disk (update)') do
         cmd = "alt_rootvg_op -C -b update_all -l #{@new_resource.image_location}"
@@ -252,7 +247,7 @@ def find_and_check_disk(type, value)
     if test == 'BIGGER' || test == 'EQUAL'
       Chef::Log.debug('alt_disk: disk is BIGGER or EQUAL')
       return disk
-      elif test == 'LESSER'
+    elsif test == 'LESSER'
       Chef::Log.debug('alt_disk: cannot find any disk usable for alt_disk')
       return 'None'
     end

--- a/providers/altdisk.rb
+++ b/providers/altdisk.rb
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
-
 use_inline_resources
 
 # support whyrun

--- a/providers/bootlist.rb
+++ b/providers/bootlist.rb
@@ -25,8 +25,7 @@ end
 def load_current_resource
   @current_resource = Chef::Resource::AixBootlist.new(@new_resource.name)
 
-  so = shell_out("bootlist -m #{@new_resource.mode} -o")
-  raise("#{cmd}: error running #{cmd} -x") if so.exitstatus != 0
+  so = shell_out!("bootlist -m #{@new_resource.mode} -o")
 
   # initialize variables
   @current_resource.devices([])
@@ -65,9 +64,7 @@ def perform_bootlist
   end
 
   converge_by("bootlist: #{cmd}") do
-    so = shell_out(cmd)
-    # if the command fails raise and exception
-    raise "no: #{cmd} failed" if so.exitstatus != 0
+    shell_out!(cmd)
   end
 end
 
@@ -113,8 +110,6 @@ action :invalidate do
   converge_by("invalidate bootlist in mode #{@new_resource.mode}") do
     cmd = "bootlist -m #{@new_resource.mode} -i "
     Chef::Log.debug("command: #{cmd}")
-    so = shell_out(cmd)
-    # if the command fails raise and exception
-    raise "no: #{cmd} failed" if so.exitstatus != 0
+    shell_out!(cmd)
   end
 end

--- a/providers/bootlist.rb
+++ b/providers/bootlist.rb
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
-
 use_inline_resources
 
 # support whyrun

--- a/providers/chdev.rb
+++ b/providers/chdev.rb
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
-
 use_inline_resources
 
 # support whyrun

--- a/providers/chdev.rb
+++ b/providers/chdev.rb
@@ -93,11 +93,7 @@ action :update do
     if set_attr
       converge_by("chdev device #{@new_resource.name} with #{@new_resource.attributes}") do
         Chef::Log.debug("command: #{string_shell_out}")
-        so = shell_out(string_shell_out)
-        # if the command fails raise and exception
-        if so.exitstatus != 0
-          raise "chdev: device #{@current_resource.name} failed"
-        end
+        shell_out!(string_shell_out)
       end
     end
   end

--- a/providers/chsec.rb
+++ b/providers/chsec.rb
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
-
 use_inline_resources
 
 # support whyrun

--- a/providers/chsec.rb
+++ b/providers/chsec.rb
@@ -97,11 +97,7 @@ action :update do
       # we converge if the is a change to do
       converge_by("chsec: changing #{@new_resource.name} for stanza #{@new_resource.stanza}") do
         Chef::Log.debug("chsec: command #{chsec_s}")
-        chsec = Mixlib::ShellOut.new(chsec_s)
-        chsec.valid_exit_codes = 0
-        chsec.run_command
-        chsec.error!
-        chsec.error?
+        shell_out!(chsec_s)
       end
     end
   end

--- a/providers/etchosts.rb
+++ b/providers/etchosts.rb
@@ -28,9 +28,7 @@ def load_current_resource
   # we say by default that the entry is no in the /etc/hosts file
   @current_resource.exists = false
 
-  hostent = Mixlib::ShellOut.new("hostent -s #{@new_resource.name}")
-  hostent.valid_exit_codes = 0
-  hostent.run_command
+  hostent = shell_out("hostent -s #{@new_resource.name}")
   if !hostent.error?
     Chef::Log.debug('etchosts: resource exists')
     @current_resource.exists = true
@@ -75,11 +73,7 @@ action :add do
     end
     converge_by("hostent: add #{@new_resource.name} in /etc/hosts file") do
       Chef::Log.debug("etchosts: running #{hostent_add_s}")
-      hostent_add = Mixlib::ShellOut.new(hostent_add_s)
-      hostent_add.valid_exit_codes = 0
-      hostent_add.run_command
-      hostent_add.error!
-      hostent_add.error?
+      shell_out!(hostent_add_s)
     end
   end
 end
@@ -90,11 +84,7 @@ action :delete do
     hostent_del_s = "hostent -d #{@new_resource.ip_address}"
     converge_by("hostent: delete #{@new_resource.ip_address}") do
       Chef::Log.debug("etchosts: running #{hostent_del_s}")
-      hostent_del = Mixlib::ShellOut.new(hostent_del_s)
-      hostent_del.valid_exit_codes = 0
-      hostent_del.run_command
-      hostent_del.error!
-      hostent_del.error?
+      shell_out!(hostent_del_s)
     end
   end
 end
@@ -146,11 +136,7 @@ action :change do
     if change
       converge_by("etchost: modifying #{@new_resource.name} in /etc/hosts") do
         Chef::Log.debug("etchosts: running #{hostent_change_s}")
-        hostent_change = Mixlib::ShellOut.new(hostent_change_s)
-        hostent_change.valid_exit_codes = 0
-        hostent_change.run_command
-        hostent_change.error!
-        hostent_change.error?
+        shell_out!(hostent_change_s)
       end
     end
   end
@@ -161,10 +147,6 @@ action :delete_all do
   hostent_del_all_s = 'hostent -X'
   converge_by('etchost: removing all entries') do
     Chef::Log.debug("etchosts: running #{hostent_del_all_s}")
-    hostent_del_all = Mixlib::ShellOut.new(hostent_del_all_s)
-    hostent_del_all.valid_exit_codes = 0
-    hostent_del_all.run_command
-    hostent_del_all.error!
-    hostent_del_all.error?
+    shell_out!(hostent_del_all_s)
   end
 end

--- a/providers/etchosts.rb
+++ b/providers/etchosts.rb
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
-
 use_inline_resources
 
 # support whyrun

--- a/providers/fixes.rb
+++ b/providers/fixes.rb
@@ -25,10 +25,7 @@ end
 def load_current_resource
   @current_resource = Chef::Resource::AixFixes.new(@new_resource.name)
 
-  emgr = Mixlib::ShellOut.new('emgr -l')
-  emgr.run_command
-  emgr.error!
-  Chef::Log.fatal('emgr: error while running emgr') unless emgr.exitstatus
+  emgr = shell_out!('emgr -l')
 
   # resource does not exists if there are no efix installed on the system
   if emgr.stdout == 'There is no efix data on this system'
@@ -52,12 +49,7 @@ action :remove do
     if @new_resource.fixes[0] == 'all'
       @current_resource.fixes.each do |fix|
         converge_by("emgr: removing fix #{fix}") do
-          remove_emgr = Mixlib::ShellOut.new("emgr -r -L #{fix}")
-          remove_emgr.run_command
-          remove_emgr.error!
-          unless remove_emgr.exitstatus
-            Chef::Log.fatal("emgr: error while trying to removing fix #{fix}")
-          end
+          shell_out!("emgr -r -L #{fix}")
         end
       end
     else
@@ -67,12 +59,7 @@ action :remove do
           converge = true if i_fix.include? fix
           next unless converge
           converge_by("emgr: removing fix #{fix}") do
-            remove_emgr = Mixlib::ShellOut.new("emgr -r -L #{fix}")
-            remove_emgr.run_command
-            remove_emgr.error!
-            unless remove_emgr.exitstatus
-              Chef::Log.fatal("emgr: error while trying to removing fix #{fix}")
-            end
+            shell_out!("emgr -r -L #{fix}")
           end
         end
       end
@@ -92,12 +79,7 @@ action :install do
     end
     next unless converge
     converge_by("emgr: installing fix #{fix}") do
-      install_emgr = Mixlib::ShellOut.new(emgr_install_string)
-      install_emgr.run_command
-      install_emgr.error!
-      unless install_emgr.exitstatus
-        Chef::Log.fatal("emgr: error while trying to install fix #{fix}")
-      end
+      shell_out!(emgr_install_string)
     end
   end
 end

--- a/providers/fixes.rb
+++ b/providers/fixes.rb
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
-
 use_inline_resources
 
 # support whyrun

--- a/providers/inittab.rb
+++ b/providers/inittab.rb
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
 use_inline_resources
 
 # Support whyrun

--- a/providers/inittab.rb
+++ b/providers/inittab.rb
@@ -26,7 +26,7 @@ def load_current_resource
   @current_resource.exists = false
 
   so = shell_out("lsitab #{@new_resource.identifier}")
-  if so.exitstatus == 0
+  unless so.error?
     @current_resource.exists = true
     fields = so.stdout.lines.first.chomp.split(':')
     # perfstat:2:once:/usr/lib/perf/libperfstat_updt_dictionary >/dev/console 2>&1

--- a/providers/multibos.rb
+++ b/providers/multibos.rb
@@ -53,8 +53,8 @@ action :create do
         string_shell_out = string_shell_out << 'a -l ' << @new_resource.update_device
       end
       Chef::Log.debug("multibos: creating standby bos with command #{string_shell_out}")
-      so = shell_out(string_shell_out, timeout: 7200)
-      if so.exitstatus != 0 || !so.stderr.empty?
+      so = shell_out!(string_shell_out, timeout: 7200)
+      if !so.stderr.empty?
         raise('multibos: error creating standby bos')
       end
     end
@@ -67,8 +67,8 @@ action :remove do
   if @current_resource.exists
     converge_by('multibos: removing standby multibos') do
       Chef::Log.debug('multibos: removing standby multibos with command multibos -RX')
-      so = shell_out('multibos -RX')
-      if so.exitstatus != 0 || !so.stderr.empty?
+      so = shell_out!('multibos -RX')
+      if !so.stderr.empty?
         raise('multibos: error removing multibos')
       end
     end
@@ -82,8 +82,8 @@ action :update do
     converge_by('mutlibos: updating standby multibos') do
       string_shell_out = 'multibos -ac -l ' << @new_resource.update_device
       Chef::Log.debug("multibos: updating standby multibos with command #{string_shell_out}")
-      so = shell_out(string_shell_out, timeout: 7200)
-      if so.exitstatus != 0 || !so.stderr.empty?
+      so = shell_out!(string_shell_out, timeout: 7200)
+      if !so.stderr.empty?
         raise('multibos: error updating multibos')
       end
     end
@@ -160,8 +160,8 @@ action :umount do
     if mounted
       Chef::Log.debug('multibos: umounting multibos')
       converge_by('multibos: umounting standby bos') do
-        stby_bos = shell_out('multibos -u')
-        if stby_bos.exitstatus != 0 || !stby_bos.stderr.empty?
+        stby_bos = shell_out!('multibos -u')
+        if !stby_bos.stderr.empty?
           Chef::Log.debug('multibos: error while multibos -m')
           raise('multibos: error while multibos -u')
         end

--- a/providers/multibos.rb
+++ b/providers/multibos.rb
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
 use_inline_resources
 
 # Support whyrun

--- a/providers/multibos.rb
+++ b/providers/multibos.rb
@@ -54,9 +54,7 @@ action :create do
       end
       Chef::Log.debug("multibos: creating standby bos with command #{string_shell_out}")
       so = shell_out!(string_shell_out, timeout: 7200)
-      if !so.stderr.empty?
-        raise('multibos: error creating standby bos')
-      end
+      raise('multibos: error creating standby bos') unless so.stderr.empty?
     end
   end
 end
@@ -68,9 +66,7 @@ action :remove do
     converge_by('multibos: removing standby multibos') do
       Chef::Log.debug('multibos: removing standby multibos with command multibos -RX')
       so = shell_out!('multibos -RX')
-      if !so.stderr.empty?
-        raise('multibos: error removing multibos')
-      end
+      raise('multibos: error removing multibos') unless so.stderr.empty?
     end
   end
 end
@@ -83,9 +79,7 @@ action :update do
       string_shell_out = 'multibos -ac -l ' << @new_resource.update_device
       Chef::Log.debug("multibos: updating standby multibos with command #{string_shell_out}")
       so = shell_out!(string_shell_out, timeout: 7200)
-      if !so.stderr.empty?
-        raise('multibos: error updating multibos')
-      end
+      raise('multibos: error updating multibos') unless so.stderr.empty?
     end
   end
 end
@@ -161,10 +155,7 @@ action :umount do
       Chef::Log.debug('multibos: umounting multibos')
       converge_by('multibos: umounting standby bos') do
         stby_bos = shell_out!('multibos -u')
-        if !stby_bos.stderr.empty?
-          Chef::Log.debug('multibos: error while multibos -m')
-          raise('multibos: error while multibos -u')
-        end
+        raise('multibos: error while multibos -u') unless stby_bos.stderr.empty?
       end
     else
       Chef::Log.debug('multibos: bos already umounted')

--- a/providers/nimclient.rb
+++ b/providers/nimclient.rb
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
 use_inline_resources
 
 # nim client reminder

--- a/providers/nimclient.rb
+++ b/providers/nimclient.rb
@@ -44,11 +44,7 @@ end
 action :set_date do
   nimclient_s = 'nimclient -d'
   converge_by("nimclient: set the client's date to that of the master") do
-    nimclient = Mixlib::ShellOut.new(nimclient_s)
-    nimclient.valid_exit_codes = 0
-    nimclient.run_command
-    nimclient.error!
-    nimclient.error?
+    shell_out!(nimclient_s)
   end
 end
 
@@ -60,11 +56,7 @@ action :enable_push do
   ps = shell_out('ps -ef | grep nimsh')
   if ps.stdout.include? '-P'
     converge_by('nimclient: enable push operation from client') do
-      nimclient = Mixlib::ShellOut.new(nimclient_s)
-      nimclient.valid_exit_codes = 0
-      nimclient.run_command
-      nimclient.error!
-      nimclient.error?
+      shell_out!(nimclient_s)
     end
   end
 end
@@ -76,11 +68,7 @@ action :disable_push do
   ps = shell_out('ps -ef | grep nimsh')
   unless ps.stdout.include? '-P'
     converge_by('nimclient: disable push operation from client') do
-      nimclient = Mixlib::ShellOut.new(nimclient_s)
-      nimclient.valid_exit_codes = 0
-      nimclient.run_command
-      nimclient.error!
-      nimclient.error?
+      shell_out!(nimclient_s)
     end
   end
 end
@@ -92,11 +80,7 @@ action :enable_crypto do
   ps = shell_out('ps -ef | grep nimsh')
   unless ps.stdout.include? '-c'
     converge_by('nimclient: enable nimsh crypto') do
-      nimclient = Mixlib::ShellOut.new(nimclient_s)
-      nimclient.valid_exit_codes = 0
-      nimclient.run_command
-      nimclient.error!
-      nimclient.error?
+      shell_out!(nimclient_s)
     end
   end
 end
@@ -108,11 +92,7 @@ action :disable_crypto do
   ps = shell_out('ps -ef | grep nimsh')
   if ps.stdout.include? '-c'
     converge_by('nimclient: disable nimsh crypto') do
-      nimclient = Mixlib::ShellOut.new(nimclient_s)
-      nimclient.valid_exit_codes = 0
-      nimclient.run_command
-      nimclient.error!
-      nimclient.error?
+      shell_out!(nimclient_s)
     end
   end
 end
@@ -153,11 +133,7 @@ action :allocate do
   # don't converge if there is nothing to allocate
   if nimclient_s != 'nimclient -o allocate'
     converge_by("nimclient: allocating resources \"#{nimclient_s}\"") do
-      nimclient = Mixlib::ShellOut.new(nimclient_s)
-      nimclient.valid_exit_codes = 0
-      nimclient.run_command
-      nimclient.error!
-      nimclient.error?
+      shell_out!(nimclient_s)
     end
   end
 end
@@ -189,11 +165,7 @@ action :maint_boot do
   if nimclient_s != 'nimclient -o maint_boot'
     unless do_not_converge
       converge_by("nimclient: maint_boot \"#{nimclient_s}\"") do
-        nimclient = Mixlib::ShellOut.new(nimclient_s)
-        nimclient.valid_exit_codes = 0
-        nimclient.run_command
-        nimclient.error!
-        nimclient.error?
+        shell_out!(nimclient_s)
       end
     end
   end
@@ -234,11 +206,7 @@ action :bos_inst do
   if nimclient_s != 'nimclient -o bos_inst'
     unless do_not_converge
       converge_by("nimclient: bos_inst \"#{nimclient_s}\"") do
-        nimclient = Mixlib::ShellOut.new(nimclient_s)
-        nimclient.valid_exit_codes = 0
-        nimclient.run_command
-        nimclient.error!
-        nimclient.error?
+        shell_out!(nimclient_s)
       end
     end
   end
@@ -326,11 +294,7 @@ action :cust do
   # converge here
   unless do_not_converge
     converge_by("nimclient cust operation: \"#{nimclient_s}\"") do
-      nimclient = Mixlib::ShellOut.new(nimclient_s, timeout: 7200)
-      nimclient.valid_exit_codes = 0
-      nimclient.run_command
-      nimclient.error!
-      nimclient.error?
+      shell_out!(nimclient_s, timeout: 7200)
     end
   end
 end
@@ -339,12 +303,7 @@ end
 # for reset and deallocate we always use the force option (-F)
 action :deallocate do
   converge_by("nimclient: deallocating all resources for client #{node['hostname']}") do
-    nimclient_s = 'nimclient -Fo deallocate -a subclass=all'
-    nimclient = Mixlib::ShellOut.new(nimclient_s)
-    nimclient.valid_exit_codes = 0
-    nimclient.run_command
-    nimclient.error!
-    nimclient.error?
+    shell_out!('nimclient -Fo deallocate -a subclass=all')
   end
 end
 
@@ -352,12 +311,7 @@ end
 # for reset and deallocate we always use the force option (-F)
 action :reset do
   converge_by("nimclient: reseting client #{node['hostname']}") do
-    nimclient_s = 'nimclient -Fo reset'
-    nimclient = Mixlib::ShellOut.new(nimclient_s)
-    nimclient.valid_exit_codes = 0
-    nimclient.run_command
-    nimclient.error!
-    nimclient.error?
+    shell_out!('nimclient -Fo reset')
   end
 end
 

--- a/providers/niminit.rb
+++ b/providers/niminit.rb
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
 use_inline_resources
 
 # Support whyrun

--- a/providers/niminit.rb
+++ b/providers/niminit.rb
@@ -23,12 +23,11 @@ end
 
 def load_current_resource
   @current_resource = Chef::Resource::AixNiminit.new(@new_resource.name)
-  @current_resource.exists = false
 
   # we assume nim client is configured if niminfo exists ...
   # Idea, checking if nimsh running will tell us its runs but we can't get config this way
   # I don't know if there is a better way to do this
-  @current_resource.exists = true if ::File.exist?('/etc/niminfo')
+  @current_resource.exists = ::File.exist?('/etc/niminfo')
 end
 
 action :setup do

--- a/providers/niminit.rb
+++ b/providers/niminit.rb
@@ -43,11 +43,7 @@ action :setup do
       connect = @new_resource.connect
       niminit_s = 'niminit -a master=' << master << ' -a name=' << name << ' -a pif_name=' << pif_name << ' -a connect=' << connect
       Chef::Log.debug("niminit: running #{niminit_s}")
-      niminit = Mixlib::ShellOut.new(niminit_s)
-      niminit.valid_exit_codes = 0
-      niminit.run_command
-      niminit.error!
-      niminit.error?
+      shell_out!(niminit_s)
     end
   end
 end
@@ -58,8 +54,7 @@ action :remove do
     converge_by('niminit: removing nimclient configuration') do
       stopsrc_s = 'stopsrc -g nimclient'
       Chef::Log.debug("niminit: stoping nimclient running #{stopsrc_s}")
-      niminit = Mixlib::ShellOut.new(stopsrc_s)
-      niminit.run_command
+      shell_out(stopsrc_s)
       # we don't care here about return code, sometime nimsh will not be runing
       # removing /etc/niminfo
       Chef::Log.debug('niminit: removing /etc/niminfo')

--- a/providers/no.rb
+++ b/providers/no.rb
@@ -100,7 +100,6 @@ action :update do
         # ... if this one is not set to the desired value add it to the no command
         else
           Chef::Log.debug("no: #{tunable} will be set to value #{value}")
-          old_string_shell_out = string_shell_out
           string_shell_out = string_shell_out << " -o #{tunable}=#{value} "
           converge_by("no: setting tunable #{tunable}=#{value}") do
             # if type is bosboot or reboot
@@ -135,7 +134,6 @@ action :reset do
       # check if attribute exists for current device, if not raising error
       if @current_resource.tunables.key?(tunable)
         Chef::Log.debug("no: reseting tunable #{tunable}")
-        old_string_shell_out = string_shell_out
         string_shell_out = string_shell_out << " -d #{tunable}"
         converge_by("no: reseting tunable #{tunable}") do
           # if type is bosboot or reboot or incremental

--- a/providers/no.rb
+++ b/providers/no.rb
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
-
 use_inline_resources
 
 # support whyrun

--- a/providers/no.rb
+++ b/providers/no.rb
@@ -28,8 +28,7 @@ def load_current_resource
   # no can always be modified so resource always exists
   @current_resource.exists = true
 
-  so = shell_out('no -x')
-  raise('no: error running no -x') if so.exitstatus != 0
+  so = shell_out!('no -x')
 
   # loading the tunables
   all_no_tunables = {}
@@ -110,9 +109,8 @@ action :update do
             end
             # TODO: here if type == B do a bosboot. Did not find any tunables with B type not implementing this
             Chef::Log.debug("command: #{string_shell_out}")
-            so = shell_out(string_shell_out)
+            shell_out!(string_shell_out)
             # if the command fails raise and exception
-            raise "no: #{string_shell_out} failed" if so.exitstatus != 0
             string_shell_out = 'no -p '
           end
         end
@@ -146,9 +144,7 @@ action :reset do
           end
           # TODO: here if type == B do a bosboot. Did not find any tunables with B type not implementing this
           Chef::Log.debug("command: #{string_shell_out}")
-          so = shell_out(string_shell_out)
-          # if the command fails raise and exception
-          raise "no: #{string_shell_out} failed" if so.exitstatus != 0
+          shell_out!(string_shell_out)
           string_shell_out = 'no -p '
         end
       else
@@ -163,7 +159,7 @@ action :reset_all do
   if @current_resource.exists
     converge_by('no : resetting all') do
       string_shell_out = 'no -D'
-      so = shell_out(string_shell_out)
+      shell_out(string_shell_out)
     end
   end
 end
@@ -173,7 +169,7 @@ action :reset_all_with_reboot do
   if @current_resource.exists
     converge_by('no : resetting all with reboot') do
       string_shell_out = 'yes | no -r -D '
-      so = shell_out(string_shell_out)
+      shell_out(string_shell_out)
     end
   end
 end

--- a/providers/pagingspace.rb
+++ b/providers/pagingspace.rb
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
-
 use_inline_resources
 
 # support whyrun

--- a/providers/pagingspace.rb
+++ b/providers/pagingspace.rb
@@ -202,9 +202,7 @@ action :create do
       # rename only if name are different
       if old_name != @new_resource.name
         shell_out!('chlv -n ' << @new_resource.name << ' ' << old_name)
-        if @new_resource.auto
-          shell_out!("chps -ay #{@new_resource.name}")
-        end
+        shell_out!("chps -ay #{@new_resource.name}") if @new_resource.auto
       end
     end
   end

--- a/providers/subserver.rb
+++ b/providers/subserver.rb
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
 use_inline_resources
 
 # Support whyrun

--- a/providers/subsystem.rb
+++ b/providers/subsystem.rb
@@ -15,10 +15,8 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
 require 'etc'
 
-include Chef::Mixin::ShellOut
 use_inline_resources
 
 # Support whyrun

--- a/providers/tcpservice.rb
+++ b/providers/tcpservice.rb
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
 use_inline_resources
 
 # Support whyrun

--- a/providers/tcpservice.rb
+++ b/providers/tcpservice.rb
@@ -23,10 +23,9 @@ end
 
 def load_current_resource
   @current_resource = Chef::Resource::AixTcpservice.new(@new_resource.name)
-  @current_resource.enabled = false
 
   so = shell_out("egrep '^start /usr/(sbin|lib)/#{@new_resource.identifier}' /etc/rc.tcpip")
-  @current_resource.enabled = true if so.exitstatus == 0
+  @current_resource.enabled = so.exitstatus == 0
 end
 
 action :enable do

--- a/providers/tunables.rb
+++ b/providers/tunables.rb
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-
-include Chef::Mixin::ShellOut
-
 use_inline_resources
 
 # support whyrun

--- a/providers/tunables.rb
+++ b/providers/tunables.rb
@@ -21,20 +21,6 @@ def whyrun_supported?
   true
 end
 
-# get command name
-def cmd
-  @new_resource.mode.to_s
-end
-
-# generate command line
-def gen_shell_out(params: nil, tunable: nil)
-  params = " -p #{params}" if @new_resource.permanent
-  if tunable && %w(R B I).include?(@current_resource.tunables[tunable][:type])
-    params.sub! '-p', '-r'
-  end
-  "#{cmd} #{params}"
-end
-
 # loading current resource
 def load_current_resource
   @current_resource = Chef::Resource::AixTunables.new(@new_resource.name)
@@ -136,4 +122,20 @@ action :reset_all do
   end
 end
 
-private :cmd, :gen_shell_out
+private
+
+# get command name
+# @api private
+def cmd
+  @new_resource.mode.to_s
+end
+
+# generate command line
+# @api private
+def gen_shell_out(params: nil, tunable: nil)
+  params = " -p #{params}" if @new_resource.permanent
+  if tunable && %w(R B I).include?(@current_resource.tunables[tunable][:type])
+    params.sub! '-p', '-r'
+  end
+  "#{cmd} #{params}"
+end

--- a/providers/tunables.rb
+++ b/providers/tunables.rb
@@ -39,8 +39,7 @@ end
 def load_current_resource
   @current_resource = Chef::Resource::AixTunables.new(@new_resource.name)
 
-  so = shell_out("#{cmd} -x")
-  raise("#{cmd}: error running #{cmd} -x") if so.exitstatus != 0
+  so = shell_out!("#{cmd} -x")
 
   # initializing tunables attribute
   all_tunables = {}
@@ -98,9 +97,7 @@ action :update do
       converge_by("#{cmd}: setting tunable #{tunable}=#{value}") do
         string_shell_out = gen_shell_out params: "-o #{tunable}=#{value} ", tunable: tunable.to_sym
         Chef::Log.debug("command: #{string_shell_out}")
-        so = shell_out(string_shell_out)
-        # if the command fails raise and exception
-        raise "no: #{string_shell_out} failed" if so.exitstatus != 0
+        shell_out!(string_shell_out)
       end
     end
   end
@@ -135,7 +132,7 @@ action :reset_all do
   converge_by("#{cmd} : resetting all") do
     string_shell_out = "#{cmd} -D"
     string_shell_out = "yes | #{cmd} -r -D" if @new_resource.nextboot
-    so = shell_out(string_shell_out)
+    shell_out(string_shell_out)
   end
 end
 

--- a/providers/wpar.rb
+++ b/providers/wpar.rb
@@ -14,14 +14,11 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
 begin
   require 'wpars'
 rescue LoadError # rubocop:disable Lint/HandleExceptions
   # This space left intentionally blank.
 end
-
-include Chef::Mixin::ShellOut
 
 use_inline_resources
 


### PR DESCRIPTION
Using the core helpers makes for nice `-l debug` debugging, you get the live stream and whatnot.

I should probably remove all the `Chef::Log.debug("whatever: running #{cmd}")` because Chef already does that logging inside mixlib-shellout. But that is at least not harmful. Also a few minor logic fixups I found along the way.