### PR TITLE
Added missing attributes

### DIFF
--- a/resources/altdisk.rb
+++ b/resources/altdisk.rb
@@ -30,3 +30,5 @@ attribute :altdisk_name, kind_of: String
 attribute :new_altdisk_name, kind_of: String
 attribute :change_bootlist, kind_of: [TrueClass, FalseClass], default: false
 attribute :image_location, kind_of: String
+attribute :reset_devices, kind_of: [TrueClass, FalseClass], default: false
+attribute :remain_nimclient, kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
### Description

Ran into issue that chef complains about undefined method. Seems that this attribute is not defined in resources/aldisk.rb. In total 2 attributes were missing. When adding those, everything went fine.


The chef code :

  aix_altdisk "Create alt_disk copy" do
    type :name
    value alt_disk
    change_bootlist true
    action [:create]
  end


Chef error :

         * aix_altdisk[Create alt_disk copy] action create

           ================================================================================
           Error executing action `create` on resource 'aix_altdisk[Create alt_disk copy]'
           ================================================================================

           NoMethodError
           -------------
           undefined method `reset_devices' for Custom resource aix_altdisk from cookbook aix



### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
