### PR TITLE
Removing duplicate xpm package for library/helpers.rb, keeping aix6.1…

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -354,7 +354,6 @@ module Opscode
           'xft' => { version: '2.1.6-5', rpm: 'xft/xft-2.1.6-5.aix5.1.ppc.rpm' },
           'xpdf' => { version: '1.00-1', rpm: 'xpdf/xpdf-1.00-1.aix4.3.ppc.rpm' },
           'xpm-devel' => { version: '3.4k-8', rpm: 'xpm/xpm-devel-3.4k-8.aix6.1.ppc.rpm' },
-          'xpm' => { version: '3.4k-8', rpm: 'xpm/xpm-3.4k-8.aix5.2.ppc.rpm' },
           'xpm' => { version: '3.4k-8', rpm: 'xpm/xpm-3.4k-8.aix6.1.ppc.rpm' },
           'xrender' => { version: '0.9.1-3', rpm: 'xrender/xrender-0.9.1-3.aix5.2.ppc.rpm' },
           'xscreensaver' => { version: '4.06-2', rpm: 'xscreensaver/xscreensaver-4.06-2.aix5.1.ppc.rpm' },

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,7 +17,7 @@
 name             'aix'
 maintainer       'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'Custom resources useful for AIX systems'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.2.1'

--- a/resources/inittab.rb
+++ b/resources/inittab.rb
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-actions :install, :remove
-
 property :identifier, name_property: true, kind_of: String
 property :runlevel, kind_of: String, required: true
 property :processaction, kind_of: String, required: true, equal_to: %w(respawn wait once boot bootwait powerfail off hold ondemand initdefault sysinit)

--- a/tasks/maintainers.rb
+++ b/tasks/maintainers.rb
@@ -39,7 +39,6 @@ begin
       end
     end
   end
-
 rescue LoadError
   STDERR.puts "\n*** TomlRb not available. Skipping the Maintainers Rake task\n\n"
 end


### PR DESCRIPTION
… version

### Description

Removes duplicate xpm from library/helpers.rb, removing the aix5.2 version while keeping the aix6.1 version.

### Issues Resolved

#74 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
