### PR TITLE
aix_chsec and library - minor updates/bugfix

### DIFF
--- a/libraries/storage_objects.rb
+++ b/libraries/storage_objects.rb
@@ -355,7 +355,7 @@ module AIXLVM
     end
 
     def mounted?
-      out = @system.run(format('mount | grep %s', @name))
+      out = @system.run(format('mount | grep -w %s', @name))
       !out.nil?
     end
 

--- a/resources/chsec.rb
+++ b/resources/chsec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-property :file_name, String, identity: true, default: lazy { |r| r.name }
+property :file_name, String, identity: true, default: lazy(&:name)
 property :attributes, Hash
 property :stanza, String, desired_state: false
 

--- a/resources/chsec.rb
+++ b/resources/chsec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-property :file_name, String, name_property: true, identity: true
+property :file_name, String, identity: true, default: lazy { |r| r.name }
 property :attributes, Hash
 property :stanza, String, desired_state: false
 
@@ -67,7 +67,7 @@ end
 
 # update action
 action :update do
-  chsec_s = "chsec -f #{new_resource.name} -s #{new_resource.stanza}"
+  chsec_s = "chsec -f #{new_resource.file_name} -s #{new_resource.stanza}"
   change = false
   # iterating trough the hash table of sec attributes
   new_resource.attributes.each do |key, value|
@@ -81,7 +81,7 @@ action :update do
   end
   if change
     # we converge if the is a change to do
-    converge_by("chsec: changing #{new_resource.name} for stanza #{new_resource.stanza}") do
+    converge_by("chsec: changing #{new_resource.file_name} for stanza #{new_resource.stanza}") do
       Chef::Log.debug("chsec: command #{chsec_s}")
       shell_out!(chsec_s)
     end


### PR DESCRIPTION
### Description

- Minor bug fix of storage_objects library and Chef 13 cloned resource error deprecation fixes.

### Issues Resolved

- Update aix_chsec to use file_name attribute (previously name attribute was used to reference file to operate on and file_name attribute was completely ignored ) which also resulted in cloned resource deprecation warnings for Chef 13 if you had to modify multiple stanzas in the same file. Behaviour of file_name is still the same, it is still optional and defaults to the name of the resource.
-  Update grep statement to ensure that when a filesystem name is a subset of another filesystem name mounted returns the correct value. i.e. When attempting to mount /b/c if /a/b/c is mounted, mounted would return true incorrectly.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
