### PR TITLE
aix_chsec simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Changes the attributes in the security stanza files.
 #### Properties
 
 - `file_name` (name_attribute) - security file to change
-- `attribute` - array of attribute to change
+- `attribute` - array of attributes to change
 - `stanza` - stanza to change
 
 #### Examples

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Custom resources useful for AIX systems'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.1'
+version          '2.2.0'
 source_url       'https://github.com/chef-cookbooks/aix'
 issues_url       'https://github.com/chef-cookbooks/aix/issues'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Custom resources useful for AIX systems'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.0'
+version          '2.2.1'
 source_url       'https://github.com/chef-cookbooks/aix'
 issues_url       'https://github.com/chef-cookbooks/aix/issues'
 

--- a/resources/chsec.rb
+++ b/resources/chsec.rb
@@ -15,8 +15,8 @@
 #
 
 property :file_name, String, name_property: true, identity: true
-property :attributes, Hash, required: true
-property :stanza, String, desired_state: false, required: true
+property :attributes, Hash
+property :stanza, String, desired_state: false
 
 ##############################
 # DEFINITIONS
@@ -33,8 +33,8 @@ def lssec(file, stanza, attribute)
 end
  
 def load_current_resource
- nr.attributes.each_key do |key|
- current_value = lssec(nr.file_name, nr.stanza, key)
+ new_res.attributes.each_key do |key|
+ current_value = lssec(new_res.file_name, new_res.stanza, key)
  current_attributes[key] = current_value if current_value
  @current_resource.attributes(current_attributes)
  end
@@ -101,13 +101,13 @@ end
 
 # update action
 action :update do
- nr = @new_resource
+ new_res = @new_resource
  chsec_attrs = []
  chsec_prefix = \
  "chsec -f '#{@new_resource.file_name}' -s '#{new_resource.stanza}'"
  
  changed_attributes.each do |key|
- chsec_attrs << "-a '#{key}'='#{nr.attributes[key]}'"
+ chsec_attrs << "-a '#{key}'='#{new_res.attributes[key]}'"
  end
  
  unless chsec_attrs.empty?

--- a/resources/chsec.rb
+++ b/resources/chsec.rb
@@ -24,32 +24,32 @@ property :stanza, String, desired_state: false
 
 # Run lssec and return value of requested attribute or false if command fails
 def lssec(file, stanza, attribute)
- cmd = shell_out("lssec -c -f '#{file}' -s '#{stanza}' -a '#{attribute}'")
- if cmd.error?
-  Chef::Log.debug("lssec: attribute '#{attribute}' not found in #{file}:#{stanza}")
-  return false
- end
- cmd.stdout.split(/\n/).last.split(':', 2).last
+  cmd = shell_out("lssec -c -f '#{file}' -s '#{stanza}' -a '#{attribute}'")
+  if cmd.error?
+    Chef::Log.debug("lssec: attribute '#{attribute}' not found in #{file}:#{stanza}")
+    return false
+  end
+  cmd.stdout.split(/\n/).last.split(':', 2).last
 end
- 
+
 def load_current_resource
- new_res.attributes.each_key do |key|
- current_value = lssec(new_res.file_name, new_res.stanza, key)
- current_attributes[key] = current_value if current_value
- @current_resource.attributes(current_attributes)
- end
+  new_res.attributes.each_key do |key|
+    current_value = lssec(new_res.file_name, new_res.stanza, key)
+    current_attributes[key] = current_value if current_value
+    @current_resource.attributes(current_attributes)
+  end
 end
- 
+
 def changed_attributes
- changed            = []
- new_attributes     = @new_resource.attributes
- current_attributes = @current_resource.attributes
- 
- new_attributes.each_key do |key, value|
- changed << key unless current_attributes[key.to_sym] == value
- end
- 
- changed
+  changed = []
+  new_attributes     = @new_resource.attributes
+  current_attributes = @current_resource.attributes
+
+  new_attributes.each_key do |key, value|
+    changed << key unless current_attributes[key.to_sym] == value
+  end
+
+  changed
 end
 
 load_current_value do |desired|
@@ -101,19 +101,19 @@ end
 
 # update action
 action :update do
- new_res = @new_resource
- chsec_attrs = []
- chsec_prefix = \
- "chsec -f '#{@new_resource.file_name}' -s '#{new_resource.stanza}'"
- 
- changed_attributes.each do |key|
- chsec_attrs << "-a '#{key}'='#{new_res.attributes[key]}'"
- end
- 
- unless chsec_attrs.empty?
-  chsec = "#{chsec_prefix} #{chsec_attrs.join(' ')}"
-  converge_by chsec do
-  shell_out!(chsec)
+  new_res = @new_resource
+  chsec_attrs = []
+  chsec_prefix = \
+    "chsec -f '#{@new_resource.file_name}' -s '#{new_resource.stanza}'"
+
+  changed_attributes.each do |key|
+    chsec_attrs << "-a '#{key}'='#{new_res.attributes[key]}'"
   end
- end
+
+  unless chsec_attrs.empty?
+    chsec = "#{chsec_prefix} #{chsec_attrs.join(' ')}"
+    converge_by chsec do
+      shell_out!(chsec)
+    end
+  end
 end

--- a/resources/chsec.rb
+++ b/resources/chsec.rb
@@ -15,42 +15,8 @@
 #
 
 property :file_name, String, name_property: true, identity: true
-property :attributes, Hash, required: true
-property :stanza, String, desired_state: false, required: true
-
-##############################
-# DEFINITIONS
-##############################
-
-# Run lssec and return value of requested attribute or false if command fails
-def lssec(file, stanza, attribute)
-  cmd = shell_out("lssec -c -f '#{file}' -s '#{stanza}' -a '#{attribute}'")
-  if cmd.error?
-    Chef::Log.debug("lssec: attribute '#{attribute}' not found in #{file}:#{stanza}")
-    return false
-  end
-  cmd.stdout.split(/\n/).last.split(':', 2).last
-end
-
-def load_current_resource
-  nr.attributes.each_key do |key|
-    current_value = lssec(nr.file_name, nr.stanza, key)
-    current_attributes[key] = current_value if current_value
-    @current_resource.attributes(current_attributes)
-  end
-end
-
-def changed_attributes
-  changed = []
-  new_attributes     = @new_resource.attributes
-  current_attributes = @current_resource.attributes
-
-  new_attributes.each_key do |key, value|
-    changed << key unless current_attributes[key.to_sym] == value
-  end
-
-  changed
-end
+property :attributes, Hash
+property :stanza, String, desired_state: false
 
 ##############################
 # DEFINITIONS
@@ -135,7 +101,6 @@ end
 
 # update action
 action :update do
-<<<<<<< HEAD
  new_res = @new_resource
  chsec_attrs = []
  chsec_prefix = \
@@ -149,25 +114,6 @@ action :update do
   chsec = "#{chsec_prefix} #{chsec_attrs.join(' ')}"
   converge_by chsec do
   shell_out!(chsec)
-=======
-  nr = @new_resource
-  chsec_attrs = []
-  chsec_prefix = \
-    "chsec -f '#{@new_resource.file_name}' -s '#{new_resource.stanza}'"
-
-  changed_attributes.each do |key|
-    chsec_attrs << "-a '#{key}'='#{nr.attributes[key]}'"
->>>>>>> branch 'Chef13upgrade' of https://github.com/srctarget/aix.git
   end
-<<<<<<< HEAD
  end
-=======
-
-  unless chsec_attrs.empty?
-    chsec = "#{chsec_prefix} #{chsec_attrs.join(' ')}"
-    converge_by chsec do
-      shell_out!(chsec)
-    end
-  end
->>>>>>> branch 'Chef13upgrade' of https://github.com/srctarget/aix.git
 end


### PR DESCRIPTION
### Description

This is bringing forward some of the changes (Descriptions included below) from https://github.com/chef-cookbooks/aix/pull/59  :
Simplify ```aix_chsec```
make attributes and stanza properties required for ```aix_chsec```
Version bump to 2.2.1
Would close PR #59 with this PR

### Issues Resolved

see above, non-documented but experienced in local testing

### Check List

- [rspec passes] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [n/a] New functionality includes testing.
- [n/a] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
