### PR TITLE
Fix previous bug introduced by commit 6a1b6261be514b40a7e624d21b1913c…

### DIFF
--- a/resources/chsec.rb
+++ b/resources/chsec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-property :file_name, String, identity: true, default: lazy(&:name)
+property :file_name, String, name_property: true 
 property :attributes, Hash
 property :stanza, String, desired_state: false
 

--- a/resources/chsec.rb
+++ b/resources/chsec.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-property :file_name, String, name_property: true 
+property :file_name, String, name_property: true
 property :attributes, Hash
 property :stanza, String, desired_state: false
 


### PR DESCRIPTION
…bd0d73b45

Signed-off-by: Navdeep Dhaliwal <34124607+navdeepd@users.noreply.github.com>

### Description

Assigning default attribute was resulting in a silent error (no errors being outputted), when using name as file_name.

Apologies as this bug was introduced due to an oversight on my part when re-mediating the rubocop finding.

### Issues Resolved

Issue reported against pull 86 has been resolved.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
