### PR TITLE
update etchosts resource to update aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,8 @@ Add, change or remove entries in the /etc/hosts file.
 
 #### Actions
 
+To ensure an entry is added and stays set correctly, use both the :add and :change actions as shown in the 5th example below.
+
 - `add` - add an entry in /etc/hosts
 - `delete` - remove an entry in /etc/hosts
 - `delete_all` - remove all entries in /etc/hosts
@@ -479,6 +481,15 @@ aix_etchosts "test" do
 end
 
 aix_etchosts "test" do
+  action :delete
+end
+
+aix_etchosts '1.1.1.4' do
+  aliases ['test4', 'test5']
+  action [:add, :change]
+end
+
+aix_etchosts "1.1.1.4" do
   action :delete
 end
 

--- a/resources/etchosts.rb
+++ b/resources/etchosts.rb
@@ -14,49 +14,40 @@
 # limitations under the License.
 #
 
-property :ip_address, String
-property :new_hostname, String
-property :aliases, Array
+# When modifying /etc/hosts, the hostent command treats hostnames and aliases as equivelent
+property :ip_address, [String, nil], default: nil
+property :new_hostname, [String, nil], default: nil
+property :aliases, Array, default: []
 
 load_current_value do |desired|
   hostent = shell_out("hostent -s #{desired.name}")
   Chef::Log.debug("command: #{hostent}")
   current_value_does_not_exist! if hostent.exitstatus != 0
+  Chef::Log.debug("etchosts: current resource: #{hostent}")
 
-  # if resource exists loads its attributes
-  Chef::Log.debug('etchosts: resource exists loading attributes')
+  # TODO: hostent can return multiple IPs and names.
   hostent_array = hostent.stdout.split(' ')
-  Chef::Log.debug("etchosts: current resource ip address: #{hostent_array[0]}")
-  ip_address hostent_array[0]
-  name hostent_array[1]
-  Chef::Log.debug("etchosts: current resource name: #{hostent_array[1]}")
-  # Initialize array for current aliases
-  current_aliases = []
-  # filling the array with the aliases if there are aliases
-  if hostent_array.length > 2
-    (2..hostent_array.length - 1).each do |i|
-      Chef::Log.debug("etchosts: current adding alias: #{hostent_array[i]}")
-      current_aliases.push(hostent_array[i])
-    end
-  end
-  Chef::Log.debug("etchosts: current resource aliases : #{current_aliases}")
-  aliases current_aliases
+  ip_address hostent_array.shift
+  aliases hostent_array
 end
 
 # add
 action :add do
   unless current_resource
-    hostent_add_s = "hostent -a #{new_resource.ip_address} -h \"#{new_resource.name}"
-    # add aliases if there are aliases
-    unless new_resource.aliases.nil?
-      # add each aliases to the command line
-      (0..new_resource.aliases.length - 1).each do |i|
-        hostent_add_s << " #{new_resource.aliases[i]}"
-      end
+    # dup array so it can be modified
+    hostnames_a = new_resource.aliases.dup
+
+    # if IP address not explicitly defined, assume it's the resource name
+    if new_resource.ip_address.nil?
+      ip = new_resource.name
+    else
+      ip = new_resource.ip_address
+      # prepend resource name to array of aliases
+      hostnames_a.unshift(new_resource.name)
     end
-    # close last double quote
-    hostent_add_s << '"'
-    # TODO: There isn't anything here to add aliases after the first name exists
+
+    hostnames_s = hostnames_a.join(' ')
+    hostent_add_s = "hostent -a #{ip} -h \"#{hostnames_s}\""
     converge_by("hostent: add #{new_resource.name} in /etc/hosts file") do
       Chef::Log.debug("etchosts: running #{hostent_add_s}")
       shell_out!(hostent_add_s)
@@ -69,7 +60,7 @@ action :delete do
   if current_resource
     hostent_del_s = "hostent -d #{current_value.ip_address}"
     converge_by("hostent: delete #{current_value.ip_address}") do
-      Chef::Log.warn("etchosts: running #{hostent_del_s}")
+      Chef::Log.debug("etchosts: running #{hostent_del_s}")
       shell_out!(hostent_del_s)
     end
   end
@@ -79,52 +70,40 @@ end
 action :change do
   if current_resource
     change = false
-    hostent_change_s = "hostent -c #{current_value.ip_address} "
-    # if new_hostname attribute exists, we need to change hostname
-    # CASE1 hostname is changing
-    if !new_resource.new_hostname.nil?
-      if new_resource.new_hostname != current_value.name
+
+    # Initialize hostent command.
+    # It is keyed off of the IP existing in /etc/hosts from load_current_value
+    hostent_change_s = "hostent -c #{current_value.ip_address} -h \""
+
+    # dup array so it can be modified
+    hostnames_a = new_resource.aliases.dup
+
+    # If new_resource.new_hostname is defined, pre-pend new_hostname to hostnames/aliases
+    hostnames_a.unshift(new_resource.new_hostname) unless new_resource.new_hostname.nil?
+
+    # join hostnames so they can be easily compared and used in command string
+    aliases_current_s = current_value.aliases.join(' ')
+    aliases_new_s = hostnames_a.join(' ')
+
+    # Check if IP address is changing
+    if !new_resource.ip_address.nil? && new_resource.ip_address != current_value.ip_address
+      if property_is_set?(:ip_address)
+        hostent_change_s << aliases_current_s
+        hostent_change_s << '"'
+        hostent_change_s << " -i #{new_resource.ip_address}"
         change = true
-        hostent_change_s << "-h \"#{new_resource.new_hostname} "
-        # CASE2 hostname and aliases are changing
-        unless new_resource.aliases.nil?
-          # add each aliases to the command line
-          (0..new_resource.aliases.length - 1).each do |i|
-            hostent_change_s << " #{new_resource.aliases[i]}"
-          end
-        end
-        # close last double quote
-        hostent_change_s << '" '
       end
     else
-      hostent_change_s << "-h \"#{new_resource.name}\" "
+      # Hostnames/aliases are changing
+      hostent_change_s << aliases_new_s
+      hostent_change_s << '"'
+      change = true if aliases_current_s != aliases_new_s
     end
-    # CASE3 ip is changing
-    # if ip_address are different change them
-    unless new_resource.ip_address.nil?
-      if new_resource.ip_address != current_value.ip_address
-        # CASE4 ip and aliases are changing
-        unless new_resource.aliases.nil?
-          hostent_change_s << "-h \"#{current_value.name} "
-          unless new_resource.aliases.nil?
-            # add each aliases to the command line
-            (0..new_resource.aliases.length - 1).each do |i|
-              hostent_change_s << " #{new_resource.aliases[i]}"
-            end
-          end
-          # close last double quote
-          hostent_change_s = hostent_change_s << '" '
-        end
-        change = true
-        if property_is_set?(:ip_address)
-          hostent_change_s << "-i #{new_resource.ip_address}"
-        end
-      end
-    end
-    # TODO: There isn't anything here to handle if aliases change
+
+    # If IP or hostnames changed, converge
     if change
       converge_by("etchost: modifying #{new_resource.name} in /etc/hosts") do
-        Chef::Log.debug("etchosts: running #{hostent_change_s}")
+        Chef::Log.warn("etchosts: running #{hostent_change_s}")
         shell_out!(hostent_change_s)
       end
     end

--- a/resources/etchosts.rb
+++ b/resources/etchosts.rb
@@ -60,7 +60,7 @@ action :delete do
   if current_resource
     hostent_del_s = "hostent -d #{current_value.ip_address}"
     converge_by("hostent: delete #{current_value.ip_address}") do
-      Chef::Log.debug("etchosts: running #{hostent_del_s}")
+      Chef::Log.warn("etchosts: running #{hostent_del_s}")
       shell_out!(hostent_del_s)
     end
   end
@@ -103,7 +103,7 @@ action :change do
     # If IP or hostnames changed, converge
     if change
       converge_by("etchost: modifying #{new_resource.name} in /etc/hosts") do
-        Chef::Log.warn("etchosts: running #{hostent_change_s}")
+        Chef::Log.debug("etchosts: running #{hostent_change_s}")
         shell_out!(hostent_change_s)
       end
     end
@@ -116,7 +116,7 @@ action :delete_all do
   if so.exitstatus == 0
     hostent_del_all_s = 'hostent -X'
     converge_by('etchost: removing all entries') do
-      Chef::Log.debug("etchosts: running #{hostent_del_all_s}")
+      Chef::Log.warn("etchosts: running #{hostent_del_all_s}")
       shell_out!(hostent_del_all_s)
     end
   end

--- a/resources/test_etchosts.rb
+++ b/resources/test_etchosts.rb
@@ -1,0 +1,79 @@
+
+File.foreach('/etc/hosts') do |line|
+  raise 'ERROR: Test IP addresses found in /etc/hosts. Aborting to prevent changes.' if line =~ /^1.1.1.[0123456]/
+  raise 'ERROR: Test hostnames found in /etc/hosts. Aborting to prevent changes.' if line =~ /test[123456]/
+end
+
+aix_etchosts 'test1' do
+  ip_address '1.1.1.1'
+  action :add
+end
+
+aix_etchosts 'test2.0' do
+  ip_address '1.1.1.2'
+  aliases ['test2.1', 'test2.2']
+  action :add
+end
+
+aix_etchosts 'test3_setup' do
+  name 'test3'
+  ip_address '1.1.1.0'
+  action :add
+end
+
+aix_etchosts 'test3' do
+  ip_address '1.1.1.3'
+  action :change
+end
+
+aix_etchosts 'test4_setup' do
+  name 'test4.0'
+  ip_address '1.1.1.4'
+  action :add
+end
+
+aix_etchosts 'test4.0' do
+  new_hostname 'test4.1'
+  action :change
+end
+
+aix_etchosts 'test5_setup' do
+  name 'test5.0'
+  ip_address '1.1.1.5'
+  action :add
+end
+
+aix_etchosts '1.1.1.5' do
+  aliases ['test5.0', 'test5.1']
+  action :change
+end
+
+aix_etchosts '1.1.1.6' do
+  aliases ['test6.0', 'test6.1']
+  action [:add, :change]
+end
+
+aix_etchosts '1.1.1.1' do
+  action :delete
+end
+
+aix_etchosts '1.1.1.2' do
+  action :delete
+end
+
+aix_etchosts '1.1.1.3' do
+  action :delete
+end
+
+aix_etchosts '1.1.1.4' do
+  action :delete
+end
+
+aix_etchosts '1.1.1.5' do
+  action :delete
+end
+
+aix_etchosts '1.1.1.6' do
+  action :delete
+end
+

--- a/test/test_etchosts/recipes/test_etchosts.rb
+++ b/test/test_etchosts/recipes/test_etchosts.rb
@@ -76,4 +76,3 @@ end
 aix_etchosts '1.1.1.6' do
   action :delete
 end
-


### PR DESCRIPTION
### Description

The etchosts resource was mostly refactored to be able to compare and update aliases.  Previously, once an entry was created, aliases could not be added or removed.  The underlying hostent command does not distinguish between a single hostname and an alias (see online [man page](https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/com.ibm.aix.cmds2/hostent.htm)).  This pull request eliminates separating out a single hostname from aliases and combines them into an array, which can be more easily compared and simplifies the overall custom resource.

The resource name can also use the IP address.  The underlying AIX hostent command uses a search keyword to identify 1 or more entries.  Searching by IP address tends to be more reliable.

### Issues Resolved

#91 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
