### PR TITLE
Fix #94 - "aix_chdev" chokes on string attributes

### DIFF
--- a/resources/chdev.rb
+++ b/resources/chdev.rb
@@ -51,6 +51,7 @@ action :update do
   new_resource.attributes.each do |attribute, value|
     # force string or else string comparison below does not work on integers
     value = value.to_s
+    attribute = attribute.downcase.to_sym unless attribute.is_a? Symbol
     # check if attribute exists for current device, if not raising error
     if current_value.attributes.key?(attribute)
       Chef::Log.debug("chdev #{current_value.name} attribute #{attribute} with value #{value}")


### PR DESCRIPTION
### Description

This PR allows use of string attribute names in the `aix_chdev` resource by converting attributes supplied by the user to be lower case symbols.

### Issues Resolved

Fixes #94 "aix_chdev" chokes on string attributes

### Check List

- [Y] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable
- [Y] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Richard Nixon <richard.nixon@btinternet.com>
