### PR TITLE
Change the providers because custom resources no longer have Chef::Resource class names.

### DIFF
--- a/providers/altdisk.rb
+++ b/providers/altdisk.rb
@@ -23,7 +23,7 @@ end
 
 # loading current resource
 def load_current_resource
-  @current_resource = Chef::Resource::AixAltdisk.new(@new_resource.name)
+  @current_resource = new_resource.class.new(@new_resource.name)
   @current_resource.exists = false
 
   # if there is no altdisk_name specified in the recipe the altdisk_name will be the default one

--- a/providers/bootlist.rb
+++ b/providers/bootlist.rb
@@ -23,7 +23,7 @@ end
 
 # loading current resource
 def load_current_resource
-  @current_resource = Chef::Resource::AixBootlist.new(@new_resource.name)
+  @current_resource = new_resource.class.new(@new_resource.name)
 
   so = shell_out!("bootlist -m #{@new_resource.mode} -o")
 

--- a/providers/fixes.rb
+++ b/providers/fixes.rb
@@ -23,7 +23,7 @@ end
 
 # loading current resource
 def load_current_resource
-  @current_resource = Chef::Resource::AixFixes.new(@new_resource.name)
+  @current_resource = new_resource.class.new(@new_resource.name)
 
   emgr = shell_out('/usr/sbin/emgr -l')
   Chef::Log.fatal('emgr: error while running emgr') if emgr.error?

--- a/providers/multibos.rb
+++ b/providers/multibos.rb
@@ -23,7 +23,7 @@ end
 
 # load current resource
 def load_current_resource
-  @current_resource = Chef::Resource::AixMultibos.new(@new_resource.name)
+  @current_resource = new_resource.class.new(@new_resource.name)
   @current_resource.exists = false
 
   # if bos_hd5 and hd5 exists there is a standby bos

--- a/providers/niminit.rb
+++ b/providers/niminit.rb
@@ -22,7 +22,7 @@ def whyrun_supported?
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::AixNiminit.new(@new_resource.name)
+  @current_resource = new_resource.class.new(@new_resource.name)
 
   # we assume nim client is configured if niminfo exists ...
   # Idea, checking if nimsh running will tell us its runs but we can't get config this way

--- a/providers/pagingspace.rb
+++ b/providers/pagingspace.rb
@@ -23,7 +23,7 @@ end
 
 # loading current resource
 def load_current_resource
-  @current_resource = Chef::Resource::AixPagingspace.new(@new_resource.name)
+  @current_resource = new_resource.class.new(@new_resource.name)
 
   lsps = shell_out("lsps -ca | grep ^#{@new_resource.name}")
   # lsps.error!

--- a/providers/subserver.rb
+++ b/providers/subserver.rb
@@ -22,7 +22,7 @@ def whyrun_supported?
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::AixSubserver.new(@new_resource.name)
+  @current_resource = new_resource.class.new(@new_resource.name)
   @current_resource.enabled = false
 
   valid_protocols = %w(tcp udp tcp6 udp6)

--- a/providers/subsystem.rb
+++ b/providers/subsystem.rb
@@ -25,7 +25,7 @@ def whyrun_supported?
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::AixSubsystem.new(@new_resource.name)
+  @current_resource = new_resource.class.new(@new_resource.name)
   @current_resource.exists = false
   so = shell_out("lssrc -S -s #{@new_resource.subsystem_name}")
   return if so.stdout.lines.empty?

--- a/providers/wpar.rb
+++ b/providers/wpar.rb
@@ -26,7 +26,7 @@ end
 # loading current resource
 def load_current_resource
   require_wpar_gem
-  @current_resource = Chef::Resource::AixWpar.new(@new_resource.name)
+  @current_resource = new_resource.class.new(@new_resource.name)
 
   # get all WPAR on the system
   wpars = ::WPAR::WPARS.new


### PR DESCRIPTION
Signed-off-by: Joshua Justice <jjustice6@bloomberg.net>

### Description

Switch from using `Chef::Resource::(class name).new` to using `new_resource.class.new`.

Please note that this does not change all providers in the cookbook, as several of the providers reference classes that are defined under libraries/.

### Issues Resolved

We encountered the following issue testing Chef 14 on AIX with our cookbooks.

```
[2018-05-09T17:50:02-04:00] INFO: *** Chef 14.1.1 ***
[2018-05-09T17:50:02-04:00] INFO: Platform: powerpc-aix6.1.0.0
[2018-05-09T17:50:11-04:00] DEBUG: Platform is aix version 7.1
...
[2018-05-09T17:50:15-04:00] INFO: Loading cookbooks [aix@2.2.0, (other stuff)
...
[2018-05-09T17:50:28-04:00] DEBUG: Loading cookbook aix's providers from /var/chef/cache/cookbooks/aix/providers/subsystem.rb
[2018-05-09T17:50:28-04:00] DEBUG: Loading cookbook aix's resources from /var/chef/cache/cookbooks/aix/resources/subsystem.rb
...
NameError: aix_subsystem[our stuff] (/var/chef/cache/cookbooks/poise-service-aix/files/halite_gem/poise_service/aix/provider.rb line 60) had an error: NameError: uninitialized constant Chef::Resource::AixSubsystem
>>>> Caused by NameError: uninitialized constant Chef::Resource::AixSubsystem
/var/chef/cache/cookbooks/aix/providers/subsystem.rb:28:in `load_current_resource'
```

This led to a discussion in the Chef community slack where @coderanger proposed this fix.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing. (no new functionality)
- [x] New functionality has been documented in the README if applicable (no new functionality)
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
