### PR TITLE
change current_value to current_resource for Chef 14

### DIFF
--- a/resources/chdev.rb
+++ b/resources/chdev.rb
@@ -45,28 +45,27 @@ end
 action :update do
   set_attr = false
   # the command will always begin with chdev -l
-  string_shell_out = 'chdev -l ' << current_value.name
+  string_shell_out = 'chdev -l ' << current_resource.name
   # for each attributes ...
-  Chef::Log.debug(new_resource.attributes)
   new_resource.attributes.each do |attribute, value|
     # force string or else string comparison below does not work on integers
     value = value.to_s
     # check if attribute exists for current device, if not raising error
-    if current_value.attributes.key?(attribute)
-      Chef::Log.debug("chdev #{current_value.name} attribute #{attribute} with value #{value}")
+    if current_resource.attributes.key?(attribute)
+      Chef::Log.debug("chdev #{current_resource.name} attribute #{attribute} with value #{value}")
       # ... if this one is already set to the desired value do nothing
-      current_resource_attr = current_value.attributes[attribute]
+      current_resource_attr = current_resource.attributes[attribute]
       Chef::Log.debug("comparing current resource #{attribute}=#{current_resource_attr} to value #{value}")
       if current_resource_attr == value
-        Chef::Log.debug("chdev: device #{current_value.name}.attribute is already set to value #{value}")
+        Chef::Log.debug("chdev: device #{current_resource.name}.attribute is already set to value #{value}")
       # ... if this one is not set to the desired value add it to the chdev command
       else
         set_attr = true
-        Chef::Log.warn("chdev: device #{current_value.name}.attribute will be set to value #{value} (previously #{current_resource_attr})")
+        Chef::Log.warn("chdev: device #{current_resource.name}.attribute will be set to value #{value} (previously #{current_resource_attr})")
         string_shell_out = string_shell_out << " -a #{attribute}=#{value}"
       end
     else
-      raise "chdev device #{current_value.name} has not attribute #{attribute}"
+      raise "chdev device #{current_resource.name} has not attribute #{attribute}"
     end
   end
   # if both -P and -U will be add raise an error (-P or -U not both)

--- a/resources/chsec.rb
+++ b/resources/chsec.rb
@@ -72,7 +72,7 @@ action :update do
   # iterating trough the hash table of sec attributes
   new_resource.attributes.each do |key, value|
     # checking if value has to be changed
-    if new_resource.attributes[key] == current_value.attributes[key]
+    if new_resource.attributes[key] == current_resource.attributes[key]
       Chef::Log.debug("chsec: value of #{key} already set to #{value} for stanza #{new_resource.stanza}")
     else
       change = true

--- a/resources/etchosts.rb
+++ b/resources/etchosts.rb
@@ -58,8 +58,8 @@ end
 # delete
 action :delete do
   if current_resource
-    hostent_del_s = "hostent -d #{current_value.ip_address}"
-    converge_by("hostent: delete #{current_value.ip_address}") do
+    hostent_del_s = "hostent -d #{current_resource.ip_address}"
+    converge_by("hostent: delete #{current_resource.ip_address}") do
       Chef::Log.warn("etchosts: running #{hostent_del_s}")
       shell_out!(hostent_del_s)
     end
@@ -73,7 +73,7 @@ action :change do
 
     # Initialize hostent command.
     # It is keyed off of the IP existing in /etc/hosts from load_current_value
-    hostent_change_s = "hostent -c #{current_value.ip_address} -h \""
+    hostent_change_s = "hostent -c #{current_resource.ip_address} -h \""
 
     # dup array so it can be modified
     hostnames_a = new_resource.aliases.dup
@@ -82,11 +82,11 @@ action :change do
     hostnames_a.unshift(new_resource.new_hostname) unless new_resource.new_hostname.nil?
 
     # join hostnames so they can be easily compared and used in command string
-    aliases_current_s = current_value.aliases.join(' ')
+    aliases_current_s = current_resource.aliases.join(' ')
     aliases_new_s = hostnames_a.join(' ')
 
     # Check if IP address is changing
-    if !new_resource.ip_address.nil? && new_resource.ip_address != current_value.ip_address
+    if !new_resource.ip_address.nil? && new_resource.ip_address != current_resource.ip_address
       if property_is_set?(:ip_address)
         hostent_change_s << aliases_current_s
         hostent_change_s << '"'

--- a/resources/no.rb
+++ b/resources/no.rb
@@ -67,13 +67,12 @@ end
 # update action
 action :update do
   # for each tunables ...
-  Chef::Log.debug(new_resource.tunables)
   new_resource.tunables.each do |tunable, value|
     # check if attribute exists for current device, if not raising error
-    if current_value.tunables.key?(tunable)
+    if current_resource.tunables.key?(tunable)
       Chef::Log.debug("no: setting tunable #{tunable} with value #{value}")
       # ... if this one is already set to the desired value do nothing
-      current_resource_tunable = current_value.tunables[tunable]['current']
+      current_resource_tunable = current_resource.tunables[tunable]['current']
       Chef::Log.debug("comparing current tunable #{tunable}=#{current_resource_tunable} to value #{value}")
       if current_resource_tunable == value
         Chef::Log.debug("no: tunable #{tunable} is already set to value #{value}")
@@ -87,7 +86,7 @@ action :update do
           string_shell_out = string_shell_out << '-p ' if new_resource.set_default
           string_shell_out = string_shell_out << " -o #{tunable}=#{value} "
           # if type is bosboot or reboot
-          if current_value.tunables[tunable]['type'] == 'R' || current_value.tunables[tunable]['type'] == 'B'
+          if current_resource.tunables[tunable]['type'] == 'R' || current_resource.tunables[tunable]['type'] == 'B'
             string_shell_out.sub! '-p', '-r'
           end
           # TODO: here if type == B do a bosboot. Did not find any tunables with B type not implementing this
@@ -105,10 +104,9 @@ end
 # reset action
 action :reset do
   # for each tunables ...
-  Chef::Log.debug(new_resource.tunables)
   new_resource.tunables.each do |tunable, _value|
     # check if attribute exists for current device, if not raising error
-    if current_value.tunables.key?(tunable)
+    if current_resource.tunables.key?(tunable)
       converge_by("no: resetting tunable #{tunable}") do
         Chef::Log.debug("no: resetting tunable #{tunable}")
         # the command will always begin with no
@@ -118,7 +116,7 @@ action :reset do
         # append -d to set tunable to default
         string_shell_out = string_shell_out << "-d #{tunable}"
         # if type is bosboot or reboot or incremental
-        if current_value.tunables[tunable]['type'] == 'R' || current_value.tunables[tunable]['type'] == 'B' || current_value.tunables[tunable]['type'] == 'I'
+        if current_resource.tunables[tunable]['type'] == 'R' || current_resource.tunables[tunable]['type'] == 'B' || current_resource.tunables[tunable]['type'] == 'I'
           string_shell_out.sub! '-p', '-r'
         end
         # TODO: here if type == B do a bosboot. Did not find any tunables with B type not implementing this

--- a/resources/subserver.rb
+++ b/resources/subserver.rb
@@ -39,7 +39,7 @@ load_current_value do |desired|
       else
         service_enabled = true
       end
-      # next unless current_value.servicename == line_array[0] && current_value.protocol == line_array[2]
+      # next unless current_resource.servicename == line_array[0] && current_resource.protocol == line_array[2]
       next unless desired.servicename == line_array[0] && desired.protocol == line_array[2]
       enabled service_enabled
       servicename line_array[0]
@@ -56,18 +56,18 @@ load_current_value do |desired|
 end
 
 action :enable do
-  if current_value.enabled
-    if current_value.type != new_resource.type ||
-       current_value.wait != new_resource.wait ||
-       current_value.user != new_resource.user ||
-       current_value.program != new_resource.program ||
-       current_value.args != new_resource.args
-      cmd = "chsubserver -c -v #{current_value.servicename} -p #{current_value.protocol}"
-      cmd << " -T #{new_resource.type}" if current_value.type != new_resource.type
-      cmd << " -W #{new_resource.wait}" if current_value.wait != new_resource.wait
-      cmd << " -U #{new_resource.user}" if current_value.user != new_resource.user
-      cmd << " -G #{new_resource.program}" if current_value.program !- new_resource.program
-      cmd << " -P #{new_resource.protocol}" if current_value.protocol != new_resource.protocol
+  if current_resource.enabled
+    if current_resource.type != new_resource.type ||
+       current_resource.wait != new_resource.wait ||
+       current_resource.user != new_resource.user ||
+       current_resource.program != new_resource.program ||
+       current_resource.args != new_resource.args
+      cmd = "chsubserver -c -v #{current_resource.servicename} -p #{current_resource.protocol}"
+      cmd << " -T #{new_resource.type}" if current_resource.type != new_resource.type
+      cmd << " -W #{new_resource.wait}" if current_resource.wait != new_resource.wait
+      cmd << " -U #{new_resource.user}" if current_resource.user != new_resource.user
+      cmd << " -G #{new_resource.program}" if current_resource.program !- new_resource.program
+      cmd << " -P #{new_resource.protocol}" if current_resource.protocol != new_resource.protocol
       # Note, you can't change args using chsubserver, probably because args can contain spaces
       converge_by('change subserver entry') do
         shell_out(cmd)
@@ -87,9 +87,9 @@ action :enable do
 end
 
 action :disable do
-  if current_value.enabled
+  if current_resource.enabled
     converge_by('disable subserver') do
-      shell_out("chsubserver -d -v #{current_value.servicename} -p #{current_value.protocol}")
+      shell_out("chsubserver -d -v #{current_resource.servicename} -p #{current_resource.protocol}")
     end
   end
 end

--- a/resources/tunables.rb
+++ b/resources/tunables.rb
@@ -68,13 +68,13 @@ action :update do
   # for each tunables ...
   new_resource.tunables.each do |tunable, value|
     # raise error if tunable doesn't exist
-    unless current_value.tunables.key?(tunable.to_sym)
+    unless current_resource.tunables.key?(tunable.to_sym)
       raise "#{cmd}: #{tunable} does not exist"
     end
 
     Chef::Log.debug("#{cmd}: setting tunable #{tunable} with value #{value}")
     # next if value already set
-    if current_value.tunables[tunable.to_sym][:current] == value.to_s
+    if current_resource.tunables[tunable.to_sym][:current] == value.to_s
       Chef::Log.info("#{cmd}: tunable #{tunable} is already set to value #{value}")
     else
       Chef::Log.debug("#{cmd}: #{tunable} will be set to value #{value}")
@@ -86,7 +86,7 @@ action :update do
         string_shell_out = string_shell_out << '-p ' if new_resource.permanent
         string_shell_out = string_shell_out << "-o #{tunable}=#{value}"
         # if type is bosboot or reboot
-        if current_value.tunables[tunable]['type'] == 'R' || current_value.tunables[tunable]['type'] == 'B'
+        if current_resource.tunables[tunable]['type'] == 'R' || current_resource.tunables[tunable]['type'] == 'B'
           string_shell_out.sub! '-p', '-r'
         end
         # TODO: here if type == B do a bosboot. Did not find any tunables with B type not implementing this
@@ -102,14 +102,13 @@ end
 action :reset do
   cmd = new_resource.mode
   # for each tunables ...
-  Chef::Log.debug(new_resource.tunables)
   new_resource.tunables.each do |tunable, value|
     # raise error if tunable doesn't exist
-    unless current_value.tunables.key?(tunable.to_sym)
+    unless current_resource.tunables.key?(tunable.to_sym)
       raise "#{cmd}: #{tunable} does not exist"
     end
 
-    if current_value.tunables[tunable.to_sym][:current] == value.to_s
+    if current_resource.tunables[tunable.to_sym][:current] == value.to_s
       Chef::Log.info("#{cmd}: tunable #{tunable} is already set to default value #{value}")
     else
       Chef::Log.debug("#{cmd}: resetting tunable #{tunable}")
@@ -121,7 +120,7 @@ action :reset do
         # append -d to set tunable to default
         string_shell_out = string_shell_out << "-d #{tunable}"
         # if type is bosboot or reboot or incremental
-        if current_value.tunables[tunable]['type'] == 'R' || current_value.tunables[tunable]['type'] == 'B' || current_value.tunables[tunable]['type'] == 'I'
+        if current_resource.tunables[tunable]['type'] == 'R' || current_resource.tunables[tunable]['type'] == 'B' || current_resource.tunables[tunable]['type'] == 'I'
           string_shell_out.sub! '-p', '-r'
         end
         # TODO: here if type == B do a bosboot. Did not find any tunables with B type not implementing this


### PR DESCRIPTION
### Description

Fixes failures in Chef 14 by changing current_value to current_resource.

### Issues Resolved
#102 
#96 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
