### PR TITLE
Unnecessary change of directory removed in fixes provider

### DIFF
--- a/providers/fixes.rb
+++ b/providers/fixes.rb
@@ -81,7 +81,6 @@ end
 action :install do
   fix_directory = @new_resource.directory
   if Dir.exist?(fix_directory)
-    Dir.chdir(fix_directory)
     packages = if @new_resource.fixes[0].downcase == 'all'
                  Dir.glob('*.epkg.Z')
                else
@@ -94,7 +93,7 @@ action :install do
       Chef::Log.debug("emgr: installing in preview mode efix #{fix} using command: #{emgr_install_string}")
       install_emgr = shell_out(emgr_install_string)
       if install_emgr.error?
-        Chef::Log.error("emgr: error during preview install, fix package: #{fix} skiped.")
+        Chef::Log.error("emgr: error during preview install, fix package: #{fix} skipped.")
         Chef::Log.info(install_emgr.stdout)
         next
       end


### PR DESCRIPTION
### Description

Due to a change of directory in the fixes provider, umount of temporary nfs installation directory will fail.

### Issues Resolved

#106

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
