### PR TITLE
Switch testing to use delivery via a Docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,13 @@
-# Use Travis's cointainer based infrastructure
-sudo: false
-addons:
-  apt:
-    sources:
-      - chef-current-trusty
-    packages:
-      - chefdk
+services:
+  - docker
 
-# Don't `bundle install`
-install: echo "skip bundle install"
+install:
+  - docker pull chef/chefdk
 
 branches:
   only:
     - master
 
-# Ensure we make ChefDK's Ruby the default
-before_script:
-  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-
 script:
-  - /opt/chefdk/embedded/bin/chef --version
-  - /opt/chefdk/embedded/bin/cookstyle --version
-  - /opt/chefdk/embedded/bin/foodcritic --version
-  - /opt/chefdk/bin/chef exec delivery local all
+  - docker run -t chef/chefdk chef -v
+  - docker run -v $PWD:/cookbook -w /cookbook -t chef/chefdk delivery local all


### PR DESCRIPTION
This should be faster than doing the full DK install each time.

Signed-off-by: Tim Smith <tsmith@chef.io>