### PR TITLE
Fixes: undefined method current_resource for Custom resource aix_wpar from c…

### DIFF
--- a/resources/wpar.rb
+++ b/resources/wpar.rb
@@ -39,8 +39,8 @@ load_current_value do |new_resource|
   current_value_does_not_exist! if wpar.nil?
 
   wpar.live_stream = STDOUT if new_resource.live_stream
-  current_resource.wpar_state = wpar.general.state
-  current_resource.cpu = wpar.resource_control.cpu
+  wpar_state = wpar.general.state
+  cpu = wpar.resource_control.cpu
   unless wpar.networks.first.nil?
     address wpar.networks.first.address
     interface wpar.networks.first.interface
@@ -58,7 +58,6 @@ end
 # create action
 action :create do
   options = {}
-  Chef::Log.debug("wpar #{current_resource.wpar_state} ")
   if current_resource
     Chef::Log.info("wpar #{new_resource.wpar_name} already exist")
   else


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
`current_resource` named used in `local_current_value` block which causes the problem.

### Issues Resolved
<!--- List any existing issues this PR resolves -->
Fixes: https://github.com/chef-cookbooks/aix/issues/125

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>